### PR TITLE
fix #3; unbound variable; show menu by default

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -350,7 +350,7 @@ esac
 
 export NAME=$0
 
-case $1 in 
+case ${1:-} in 
 
 v1UNIX) run_v1UNIX; exit;;
 v5UNIX) run_v5UNIX; exit;;


### PR DESCRIPTION
This PR resolves the error in which `run.sh` returns the following error:

```sh
run.sh: line 353: $1: unbound variable
```